### PR TITLE
scripts: {main.js, market: various}: Add version split for Japanese

### DIFF
--- a/script_conversion/market/32bit_base_relative_writes.json
+++ b/script_conversion/market/32bit_base_relative_writes.json
@@ -204,7 +204,7 @@
         "value": "0x021070A0"
       },
       {
-        "language": "Japanese",
+        "language": "Japanese Rev5",
         "name": "base_address",
         "value": "0x02108818"
       },

--- a/script_conversion/market/TIDSID_editor.json
+++ b/script_conversion/market/TIDSID_editor.json
@@ -219,7 +219,7 @@
           "value": "0x021070A0"
         },
         {
-          "language": "Japanese",
+          "language": "Japanese Rev5",
           "name": "base_address",
           "value": "0x02108818"
         },

--- a/script_conversion/market/ase_bootstrap.json
+++ b/script_conversion/market/ase_bootstrap.json
@@ -232,9 +232,14 @@
         "value": "0x020584ec"
       },
       {
-        "language": "Japanese",
+        "language": "Japanese Rev5",
         "name": "FUN_setMoveCode",
         "value": "0x0205b4e0"
+      },
+      {
+        "language": "Japanese Rev6",
+        "name": "FUN_setMoveCode",
+        "value": "0x0205b5CC"
       },
       {
         "language": "English",
@@ -262,12 +267,17 @@
         "value": "0x206ec30"
       },
       {
-        "language": "Japanese",
+        "language": "Japanese Rev5",
         "name": "FUN_GetItemData",
         "value": "0x02073944"
       },
       {
-        "language": "Japanese",
+        "language": "Japanese Rev6",
+        "name": "FUN_GetItemData",
+        "value": "0x02073A42"
+      },
+      {
+        "language": "Japanese Rev5",
         "name": "SetMailMax",
         "value": "[FUN_GetItemData]+0x7C"
       },

--- a/script_conversion/market/change_rng.json
+++ b/script_conversion/market/change_rng.json
@@ -96,7 +96,7 @@
         "value": "0x021C4E28"
       },
       {
-        "language": "Japanese",
+        "language": "Japanese Rev5",
         "name": "RNG_address",
         "value": "0x021C65A0"
       },

--- a/script_conversion/market/experimental_ase_bootstrap.json
+++ b/script_conversion/market/experimental_ase_bootstrap.json
@@ -2,7 +2,7 @@
   {
     "title": "ASE Bootstrap",
     "color": "62, 147, 63",
-    "language": "Japanese",
+    "language": "English",
     "input_fields": [
       {
         "type": "command",
@@ -143,9 +143,14 @@
         "value": "0x203C5D4"
       },
       {
-        "language": "Japanese",
+        "language": "Japanese Rev5",
         "name": "EvCmdNameInStone",
         "value": "0x203F75C"
+      },
+      {
+        "language": "Japanese Rev5",
+        "name": "EvCmdNameInStone",
+        "value": "0x203F800"
       }
     ],
     "documentation": ""

--- a/script_conversion/market/give_pokemon_or_egg_with_set_rng.json
+++ b/script_conversion/market/give_pokemon_or_egg_with_set_rng.json
@@ -128,7 +128,7 @@
         "value": "0x021C4E28"
       },
       {
-        "language": "Japanese",
+        "language": "Japanese Rev5",
         "name": "RNG_address",
         "value": "0x021C65A0"
       },
@@ -273,7 +273,7 @@
         "value": "0x021C4E28"
       },
       {
-        "language": "Japanese",
+        "language": "Japanese Rev5",
         "name": "RNG_address",
         "value": "0x021C65A0"
       },

--- a/script_conversion/market/random_background_generator.json
+++ b/script_conversion/market/random_background_generator.json
@@ -133,7 +133,7 @@
         "value": "0x021C4E28"
       },
       {
-        "language": "Japanese",
+        "language": "Japanese Rev5",
         "name": "RNG_address",
         "value": "0x021C65A0"
       },

--- a/script_conversion/market/walk_through_walls.json
+++ b/script_conversion/market/walk_through_walls.json
@@ -64,7 +64,7 @@
         "value": "0x2056C76"
       },
       {
-        "language": "Japanese",
+        "language": "Japanese Rev5",
         "name": "collision",
         "value": "0x20593E0"
       },

--- a/script_conversion/market/wondercard_ace.json
+++ b/script_conversion/market/wondercard_ace.json
@@ -598,7 +598,7 @@
         "value": "0x021070A0"
       },
       {
-        "language": "Japanese",
+        "language": "Japanese Rev5",
         "name": "base_address",
         "value": "0x02108818"
       },

--- a/script_conversion/scripts/main.js
+++ b/script_conversion/scripts/main.js
@@ -1207,7 +1207,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     datalists["datalist-maps"] = new MapDataList(document.documentElement, maps);
     const moves = await getJsonFromUrl(`data/move_data.json`);
     datalists["datalist-moves"] = new MoveDataList(document.documentElement, moves);
-    const languages = ["All", "English", "Japanese", "French", "Italian", "German", "Spanish", "Korean"];
+    const languages = ["All", "English", "Japanese Rev5", "Japanese Rev6", "French", "Italian", "German", "Spanish", "Korean"];
     datalists["datalist-languages"] = new LanguageDataList(document.documentElement, languages);
     const scriptFiles = await getFilesFromGithub(`VoidmatrixTeam`, `Voidmatrix`, `script_conversion/market`)
     datalists["datalist-scripts"] = new ScriptDataList(document.documentElement, scriptFiles);


### PR DESCRIPTION
Temporary commit to add version split for Japanese games. This will be reverted once a proper game version selection is implemented which includes support for Platinum and HeartGold/SoulSilver.