### PR TITLE
Make TIDSID related code work with French games

### DIFF
--- a/script_conversion/market/TIDSID_editor.json
+++ b/script_conversion/market/TIDSID_editor.json
@@ -169,6 +169,11 @@
           "value": "0x2039C04"
         },
         {
+          "language": "Japanese Rev5",
+          "name": "FUN_CompAdrsAdrs",
+          "value": "0x20422F4"
+        },
+        {
           "language": "Spanish",
           "name": "FUN_CompAdrsAdrs",
           "value": "0x2039C04"
@@ -197,6 +202,11 @@
           "language": "Italian",
           "name": "FUN_LoadAdrsAdrs",
           "value": "0x2039B14"
+        },
+        {
+          "language": "Japanese Rev5",
+          "name": "FUN_LoadAdrsAdrs",
+          "value": "0x20423F8"
         },
         {
           "language": "English",

--- a/script_conversion/market/TIDSID_editor.json
+++ b/script_conversion/market/TIDSID_editor.json
@@ -156,22 +156,22 @@
         {
           "language": "French",
           "name": "FUN_CompAdrsAdrs",
-          "value": "0x02039C2C"
+          "value": "0x2039C04"
         },
         {
           "language": "German",
           "name": "FUN_CompAdrsAdrs",
-          "value": "0x02039C2C"
+          "value": "0x2039C04"
         },
         {
           "language": "Italian",
           "name": "FUN_CompAdrsAdrs",
-          "value": "0x02039C2C"
+          "value": "0x2039C04"
         },
         {
           "language": "Spanish",
           "name": "FUN_CompAdrsAdrs",
-          "value": "0x02039C2C"
+          "value": "0x2039C04"
         },
         {
           "language": "English",
@@ -181,22 +181,22 @@
         {
           "language": "French",
           "name": "FUN_LoadAdrsAdrs",
-          "value": "0x2039B3C"
+          "value": "0x2039B14"
         },
         {
           "language": "German",
           "name": "FUN_LoadAdrsAdrs",
-          "value": "0x2039B3C"
+          "value": "0x2039B14"
         },
         {
           "language": "Spanish",
           "name": "FUN_LoadAdrsAdrs",
-          "value": "0x2039B3C"
+          "value": "0x2039B14"
         },
         {
           "language": "Italian",
           "name": "FUN_LoadAdrsAdrs",
-          "value": "0x2039B3C"
+          "value": "0x2039B14"
         },
         {
           "language": "English",

--- a/script_conversion/market/TIDSID_randomizer.json
+++ b/script_conversion/market/TIDSID_randomizer.json
@@ -103,8 +103,8 @@
           "0xbd",
           "0x0",
           "0x0",
-          "0xed",
-          "0xb9",
+          "[rngcall_lo]",
+          "[rngcall_hi]",
           "0x1",
           "0x2"
         ]
@@ -115,6 +115,31 @@
         "language": "English",
         "name": "FUN_UnusedCommand",
         "value": "0x0203E4D8"
+      },
+      {
+        "language": "French",
+        "name": "FUN_UnusedCommand",
+        "value": "0x203E520"
+      },
+      {
+        "language": "English",
+        "name": "rngcall_lo",
+        "value": "0xed"
+      },
+      {
+        "language": "French",
+        "name": "rngcall_lo",
+        "value": "0x39"
+      },
+      {
+        "language": "English",
+        "name": "rngcall_hi",
+        "value": "0xb9"
+      },
+      {
+        "language": "French",
+        "name": "rngcall_hi",
+        "value": "0xba"
       }
     ],
     "documentation": ""

--- a/script_conversion/market/TIDSID_randomizer.json
+++ b/script_conversion/market/TIDSID_randomizer.json
@@ -103,10 +103,10 @@
           "0xbd",
           "0x0",
           "0x0",
-          "[rngcall_lo]",
-          "[rngcall_hi]",
-          "0x1",
-          "0x2"
+          "[rngcall]&0xFF",
+          "[rngcall]>>8&0xFF",
+          "[rngcall]>>16&0xFF",
+          "[rngcall]>>24&0xFF"
         ]
       }
     ],
@@ -122,24 +122,34 @@
         "value": "0x203E520"
       },
       {
+        "language": "German",
+        "name": "FUN_UnusedCommand",
+        "value": "0x203E520"
+      },
+      {
+        "language": "Italian",
+        "name": "FUN_UnusedCommand",
+        "value": "0x203E520"
+      },
+      {
+        "language": "Japanese Rev5",
+        "name": "FUN_UnusedCommand",
+        "value": "0x203D664"
+      },
+      {
+        "language": "Spanish",
+        "name": "FUN_UnusedCommand",
+        "value": "0x203E520"
+      },
+      {
         "language": "English",
-        "name": "rngcall_lo",
-        "value": "0xed"
+        "name": "rngcall",
+        "value": "0x0201B9ED"
       },
       {
         "language": "French",
-        "name": "rngcall_lo",
-        "value": "0x39"
-      },
-      {
-        "language": "English",
-        "name": "rngcall_hi",
-        "value": "0xb9"
-      },
-      {
-        "language": "French",
-        "name": "rngcall_hi",
-        "value": "0xba"
+        "name": "rngcall",
+        "value": "0x0201BA39"
       }
     ],
     "documentation": ""


### PR DESCRIPTION
- Fix addresses of `FUN_LoadAdrsAdrs` and `FUN_CompAdrsAdrs` for French and other european languages in TIDSID editor
- Add support for French in TIDSID randomizer: add a parameter for the rng call address to adapt to other languages than English


I tested both codes on my French Diamond version